### PR TITLE
[nemo-qml-plugin-messages] Only register as a Telepathy handler if explicitly given a handler name

### DIFF
--- a/src/clienthandler.cpp
+++ b/src/clienthandler.cpp
@@ -43,14 +43,31 @@ using namespace Tp;
 ClientHandler::ClientHandler()
     : AbstractClientHandler(ChannelClassSpec::textChat())
 {
-    const QDBusConnection &dbus = QDBusConnection::sessionBus();
-    registrar = ClientRegistrar::create(dbus);
-    AbstractClientPtr handler = AbstractClientPtr(this);
-    registrar->registerClient(handler, "qmlmessages");
 }
 
 ClientHandler::~ClientHandler()
 {
+}
+
+QString ClientHandler::handlerName() const
+{
+    return m_handlerName;
+}
+
+void ClientHandler::setHandlerName(const QString &name)
+{
+    if (name.isEmpty() || !m_handlerName.isEmpty())
+        return;
+
+    m_handlerName = name;
+
+    const QDBusConnection &dbus = QDBusConnection::sessionBus();
+    if (registrar.isNull())
+        registrar = ClientRegistrar::create(dbus);
+    AbstractClientPtr handler = AbstractClientPtr(this);
+    registrar->registerClient(handler, m_handlerName);
+
+    emit handlerNameChanged();
 }
 
 ConversationChannel *ClientHandler::getConversation(const QString &localUid, const QString &remoteUid)

--- a/src/clienthandler.h
+++ b/src/clienthandler.h
@@ -42,9 +42,18 @@ class ClientHandler : public QObject, public Tp::AbstractClientHandler
 {
     Q_OBJECT
 
+    /* If defined, this client will be registered as a handler for Telepathy text channels.
+     * This should generally only be done by a primary messaging client that wishes to see
+     * and be responsible for new incoming channels; it's not necessary to establish new
+     * channels via getConversation. */
+    Q_PROPERTY(QString handlerName READ handlerName WRITE setHandlerName NOTIFY handlerNameChanged)
+
 public:
     ClientHandler();
     virtual ~ClientHandler();
+
+    QString handlerName() const;
+    void setHandlerName(const QString &handlerName);
 
     Q_INVOKABLE ConversationChannel *getConversation(const QString &localUid, const QString &remoteUid);
 
@@ -53,10 +62,15 @@ public:
                                 const Tp::ConnectionPtr &connection, const QList<Tp::ChannelPtr> &channels,
                                 const QList<Tp::ChannelRequestPtr> &requestsSatisfied, const QDateTime &userActionTime,
                                 const HandlerInfo &handlerInfo);
+
+signals:
+    void handlerNameChanged();
+
 private slots:
     void channelDestroyed(QObject *obj);
 
 private:
+    QString m_handlerName;
     Tp::ClientRegistrarPtr registrar;
     QList<ConversationChannel*> channels;
 };


### PR DESCRIPTION
This allows clients to register under a handler name of their choice,
and allows creation of a TelepathyChannelManager instance without
registering as a Telepathy handler (which is useful for clients that
wish to establish channels to send messages without intending to receive
or display any).

Note that text channels may be discarded by Telepathy if there is not at
least one registered handler on the system; generally, there should be a
primary messaging application that does so.
