### PR TITLE
[nemo-qml-plugin-messages] Add DeclarativeAccount wrapper for Tp::Account

### DIFF
--- a/nemomessages-internal.pro
+++ b/nemomessages-internal.pro
@@ -19,11 +19,13 @@ equals(QT_MAJOR_VERSION, 5) {
 SOURCES += plugin.cpp \
     src/accountsmodel.cpp \
     src/conversationchannel.cpp \
-    src/clienthandler.cpp
+    src/clienthandler.cpp \
+    src/declarativeaccount.cpp
 
 HEADERS += src/accountsmodel.h \
     src/conversationchannel.h \
-    src/clienthandler.h
+    src/clienthandler.h \
+    src/declarativeaccount.h
 
 INSTALLS += target
 

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -51,6 +51,7 @@
 #include "src/accountsmodel.h"
 #include "src/conversationchannel.h"
 #include "src/clienthandler.h"
+#include "src/declarativeaccount.h"
 
 class Q_DECL_EXPORT NemoMessagesPlugin : public QDeclarativeExtensionPlugin
 {
@@ -79,6 +80,8 @@ public:
         qmlRegisterUncreatableType<ConversationChannel>(uri, 1, 0, "ConversationChannel",
                 QLatin1String("Must be created via TelepathyChannelManager"));
         qmlRegisterType<ClientHandler>(uri, 1, 0, "TelepathyChannelManager");
+        qmlRegisterUncreatableType<DeclarativeAccount>(uri, 1, 0, "TelepathyAccount",
+                QLatin1String("Create via AccountsModel"));
     }
 };
 

--- a/src/accountsmodel.cpp
+++ b/src/accountsmodel.cpp
@@ -30,6 +30,7 @@
 
 #include "accountsmodel.h"
 #include "conversationchannel.h"
+#include "declarativeaccount.h"
 #include <QDBusConnection>
 #include <QDebug>
 
@@ -86,6 +87,15 @@ int AccountsModel::indexOfAccount(const QString &localUid) const
     }
 
     return -1;
+}
+
+DeclarativeAccount *AccountsModel::getAccount(const QString &uid) const
+{
+    int index = indexOfAccount(uid);
+    if (index < 0)
+        return 0;
+
+    return new DeclarativeAccount(mAccounts[index]);
 }
 
 int AccountsModel::rowCount(const QModelIndex &parent) const

--- a/src/accountsmodel.h
+++ b/src/accountsmodel.h
@@ -36,6 +36,7 @@
 #include <TelepathyQt/AccountManager>
 
 class ConversationChannel;
+class DeclarativeAccount;
 
 class AccountsModel : public QAbstractListModel
 {
@@ -71,6 +72,8 @@ public:
     }
 
     Q_INVOKABLE int indexOfAccount(const QString &localUid) const;
+
+    Q_INVOKABLE DeclarativeAccount *getAccount(const QString &localUid) const;
 
     int count() const { return rowCount(); }
     bool isReady() const { return mReady; }

--- a/src/declarativeaccount.cpp
+++ b/src/declarativeaccount.cpp
@@ -1,0 +1,95 @@
+/* Copyright (C) 2013 Jolla Ltd.
+ * Contact: John Brooks <john.brooks@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "declarativeaccount.h"
+
+DeclarativeAccount::DeclarativeAccount(const Tp::AccountPtr &a, QObject *parent)
+    : QObject(parent), account(a)
+{
+    connect(a.data(), SIGNAL(onlinenessChanged(bool)), SIGNAL(onlineChanged()));
+    connect(a.data(), SIGNAL(connectionStatusChanged(Tp::ConnectionStatus)), SIGNAL(connectionStatusChanged()));
+    connect(a.data(), SIGNAL(displayNameChanged(QString)), SIGNAL(displayNameChanged()));
+}
+
+QString DeclarativeAccount::localUid() const
+{
+    return account->objectPath();
+}
+
+QString DeclarativeAccount::displayName() const
+{
+    return account->displayName();
+}
+
+bool DeclarativeAccount::online() const
+{
+    return account->isOnline();
+}
+
+DeclarativeAccount::ConnectionStatus DeclarativeAccount::connectionStatus() const
+{
+    return static_cast<DeclarativeAccount::ConnectionStatus>(account->connectionStatus());
+}
+
+DeclarativeAccount::ConnectionStatusReason DeclarativeAccount::connectionStatusReason() const
+{
+    switch (account->connectionStatusReason()) {
+        case Tp::ConnectionStatusReasonNoneSpecified:
+            return ReasonNoneSpecified;
+        case Tp::ConnectionStatusReasonRequested:
+            return ReasonRequested;
+        case Tp::ConnectionStatusReasonNetworkError:
+            return ReasonNetworkError;
+        case Tp::ConnectionStatusReasonAuthenticationFailed:
+            return ReasonAuthenticationFailed;
+        case Tp::ConnectionStatusReasonEncryptionError:
+        case Tp::ConnectionStatusReasonCertNotProvided:
+        case Tp::ConnectionStatusReasonCertUntrusted:
+        case Tp::ConnectionStatusReasonCertExpired:
+        case Tp::ConnectionStatusReasonCertNotActivated:
+        case Tp::ConnectionStatusReasonCertHostnameMismatch:
+        case Tp::ConnectionStatusReasonCertFingerprintMismatch:
+        case Tp::ConnectionStatusReasonCertSelfSigned:
+        case Tp::ConnectionStatusReasonCertOtherError:
+        case Tp::ConnectionStatusReasonCertRevoked:
+        case Tp::ConnectionStatusReasonCertInsecure:
+        case Tp::ConnectionStatusReasonCertLimitExceeded:
+            return ReasonEncryptionError;
+        default:
+            return ReasonNoneSpecified;
+    }
+}
+
+QString DeclarativeAccount::connectionError() const
+{
+    return account->connectionError();
+}
+

--- a/src/declarativeaccount.h
+++ b/src/declarativeaccount.h
@@ -1,0 +1,84 @@
+/* Copyright (C) 2013 Jolla Ltd.
+ * Contact: John Brooks <john.brooks@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DECLARATIVEACCOUNT_H
+#define DECLARATIVEACCOUNT_H
+
+#include <QObject>
+#include <TelepathyQt/Account>
+
+class DeclarativeAccount : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(ConnectionStatus ConnectionStatusReason)
+
+    Q_PROPERTY(QString localUid READ localUid CONSTANT)
+    Q_PROPERTY(QString displayName READ displayName NOTIFY displayNameChanged)
+    Q_PROPERTY(bool online READ online NOTIFY onlineChanged)
+    Q_PROPERTY(ConnectionStatus connectionStatus READ connectionStatus NOTIFY connectionStatusChanged)
+    Q_PROPERTY(ConnectionStatusReason connectionStatusReason READ connectionStatusReason NOTIFY connectionStatusChanged)
+    Q_PROPERTY(QString connectionError READ connectionError NOTIFY connectionStatusChanged)
+
+public:
+    enum ConnectionStatus {
+        Connected = Tp::ConnectionStatusConnected,
+        Connecting = Tp::ConnectionStatusConnecting,
+        Disconnected = Tp::ConnectionStatusDisconnected
+    };
+
+    // Incomplete mapping; other values are converted to one of these choices.
+    enum ConnectionStatusReason {
+        ReasonNoneSpecified = Tp::ConnectionStatusReasonNoneSpecified,
+        ReasonRequested = Tp::ConnectionStatusReasonRequested,
+        ReasonNetworkError = Tp::ConnectionStatusReasonNetworkError,
+        ReasonAuthenticationFailed = Tp::ConnectionStatusReasonAuthenticationFailed,
+        ReasonEncryptionError = Tp::ConnectionStatusReasonEncryptionError
+    };
+
+    DeclarativeAccount(const Tp::AccountPtr &account, QObject *parent = 0);
+
+    QString localUid() const;
+    QString displayName() const;
+    bool online() const;
+    ConnectionStatus connectionStatus() const;
+    ConnectionStatusReason connectionStatusReason() const;
+    QString connectionError() const;
+
+signals:
+    void displayNameChanged();
+    void onlineChanged();
+    void connectionStatusChanged();
+
+private:
+    Tp::AccountPtr account;
+};
+
+#endif


### PR DESCRIPTION
Primarily, this provides access to the connection status and errors for an account.
