### PR TITLE
[nemo-qml-plugin-messages] Don't assert on channel state in channelReady

### DIFF
--- a/src/conversationchannel.cpp
+++ b/src/conversationchannel.cpp
@@ -173,8 +173,6 @@ void ConversationChannel::channelRequestFailed(const QString &errorName,
 
 void ConversationChannel::channelReady()
 {
-    Q_ASSERT(state() == PendingReady);
-    Q_ASSERT(!mChannel.isNull());
     if (state() != PendingReady || mChannel.isNull())
         return;
 


### PR DESCRIPTION
In some cases, channelReady is received even after we've received
channelInvalidated, at which point it's not possible that the channel is
actually useful.

We already check the state and don't accept the channel if it has
changed, so just removing the assert solves this problem.
